### PR TITLE
feat(react-web): add salt support and improve feature flag management

### DIFF
--- a/packages/react/example/src/App.tsx
+++ b/packages/react/example/src/App.tsx
@@ -6,6 +6,14 @@ import viteLogo from '/vite.svg';
 import { KnobGuard, useKnob } from '@withgates/react-web';
 import { gates } from './main';
 
+const NewComponent = ({ text }: { text: string }) => {
+  return <p>{text}</p>;
+};
+
+const OldComponent = ({ text }: { text: string }) => {
+  return <p>{text}</p>;
+};
+
 function App() {
   const [count, setCount] = useState(0);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -47,10 +55,11 @@ function App() {
       <h1>Vite + React</h1>
 
       <div className="card">
-        <KnobGuard value="feature-flag-2" fallback={<p>Feature is disabled</p>}>
-          <button onClick={() => setCount((count) => count + 1)}>
-            count is {count}
-          </button>
+        <KnobGuard
+          value="user_attributes_management"
+          fallback={<OldComponent text="Old Component" />}
+        >
+          <NewComponent text="New Component" />
         </KnobGuard>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR

--- a/packages/react/example/src/main.tsx
+++ b/packages/react/example/src/main.tsx
@@ -7,6 +7,7 @@ import './index.css';
 export const gates = new Gates('<YOUR_GATES_API_KEY>', {
   appUserId: '00000-22222',
   alwaysFetch: false,
+  salt: '<YOUR_SECRET_SALT>',
 });
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/react/example/yarn.lock
+++ b/packages/react/example/yarn.lock
@@ -662,15 +662,6 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
 
-"@withgates/react-web@*":
-  version "1.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@withgates/react-web/-/react-web-1.0.0-alpha.7.tgz#3c7da6b550f5e05b847c5573e9c6f97d19eff1eb"
-  integrity sha512-la33MbhOicE1xcbgiHjdzCJeWE3Y1eEjzqDX0cuPTsvD12iCA9wX2T0sUgHxJ2m5zNBY0MZhXjEUWV0gJmRkjg==
-  dependencies:
-    crypto-js "^4.2.0"
-    idb "^8.0.0"
-    react "^18.3.1"
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -788,11 +779,6 @@ cross-spawn@^7.0.5:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-js@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
-  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 csstype@^3.0.2:
   version "3.1.3"
@@ -1072,11 +1058,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-idb@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.0.tgz#33d7ed894ed36e23bcb542fb701ad579bfaad41f"
-  integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
 
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withgates/react-web",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "React utilities for WithGates",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/react/src/Gates.ts
+++ b/packages/react/src/Gates.ts
@@ -91,11 +91,13 @@ export class Gates extends CoreGates implements IGates {
 
   async sync() {
     const request = await this.makeRequest<GatesResponse>(
-      `sdk/gates?keys=knobs&experiments&userId=${this.user.id}`,
+      `sdk/gates?keys=knobs,experiments&userId=${this.user.id}`,
       'GET'
     );
 
     this.store = request;
+
+    await GateStorage.resetStores();
 
     await Promise.all([
       GateStorage.saveGates('knobs', request.knobs),

--- a/packages/react/src/hooks/useExperiment.ts
+++ b/packages/react/src/hooks/useExperiment.ts
@@ -29,9 +29,9 @@ export function useExperiment(key: string, defaultValue = false): boolean {
   const { gates } = useContext(GateContext) ?? {};
   const xp = gates?.store?.experiments ?? {};
 
-  const hashedKey = createHash(key, String(gates?.salt));
+  const hashedKey = gates?.salt ? createHash(key, gates.salt) : undefined;
 
-  if (xp[hashedKey]) {
+  if (hashedKey && xp[hashedKey]) {
     return xp[hashedKey];
   }
 

--- a/packages/react/src/hooks/useExperiment.ts
+++ b/packages/react/src/hooks/useExperiment.ts
@@ -29,7 +29,7 @@ export function useExperiment(key: string, defaultValue = false): boolean {
   const { gates } = useContext(GateContext) ?? {};
   const xp = gates?.store?.experiments ?? {};
 
-  const hashedKey = createHash(key);
+  const hashedKey = createHash(key, String(gates?.salt));
 
   if (xp[hashedKey]) {
     return xp[hashedKey];

--- a/packages/react/src/hooks/useKnob.ts
+++ b/packages/react/src/hooks/useKnob.ts
@@ -25,7 +25,7 @@ export function useKnob(key: string, defaultValue = false): boolean {
   const { gates } = useContext(GateContext) ?? {};
   const knobs = gates?.store?.knobs ?? {};
 
-  const hashedKey = createHash(key);
+  const hashedKey = createHash(key, String(gates?.salt));
 
   if (knobs[hashedKey]) {
     return knobs[hashedKey];

--- a/packages/react/src/hooks/useKnob.ts
+++ b/packages/react/src/hooks/useKnob.ts
@@ -25,9 +25,9 @@ export function useKnob(key: string, defaultValue = false): boolean {
   const { gates } = useContext(GateContext) ?? {};
   const knobs = gates?.store?.knobs ?? {};
 
-  const hashedKey = createHash(key, String(gates?.salt));
+  const hashedKey = gates?.salt ? createHash(key, gates.salt) : undefined;
 
-  if (knobs[hashedKey]) {
+  if (hashedKey && knobs[hashedKey]) {
     return knobs[hashedKey];
   }
 

--- a/packages/react/src/utils/hash.ts
+++ b/packages/react/src/utils/hash.ts
@@ -1,6 +1,8 @@
 import pkg from 'crypto-js';
 const { MD5 } = pkg;
 
-export function createHash(value: string) {
-  return MD5(value).toString().slice(0, 6);
+export function createHash(value: string, salt: string) {
+  return MD5(salt + value)
+    .toString()
+    .slice(0, 6);
 }

--- a/packages/react/src/utils/storage.ts
+++ b/packages/react/src/utils/storage.ts
@@ -105,8 +105,20 @@ export class GateStorage {
 
   // Cleanup all stale entries across all stores
   static async cleanupAll() {
-    for (const store of STORES) {
-      await this.cleanup(store);
-    }
+    await Promise.all(STORES.map((store) => this.cleanup(store)));
+  }
+
+  static async resetStores() {
+    const db = await openDB(DB_NAME, DB_VERSION);
+    const tx = db.transaction(STORES, 'readwrite');
+
+    await Promise.all(
+      STORES.map(async (storeName) => {
+        const store = tx.objectStore(storeName);
+        await store.clear();
+      })
+    );
+
+    await tx.done;
   }
 }

--- a/packages/react/src/utils/storage.ts
+++ b/packages/react/src/utils/storage.ts
@@ -112,7 +112,7 @@ export class GateStorage {
     const db = await openDB(DB_NAME, DB_VERSION);
     const tx = db.transaction(STORES, 'readwrite');
 
-    await Promise.all(
+    await Promise. allSettled(
       STORES.map(async (storeName) => {
         const store = tx.objectStore(storeName);
         await store.clear();

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,20 +680,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.26.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.7.tgz#99a0a136f6a75e7fb8b0a1ace421e0b25994b8bb"
-  integrity sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==
-  dependencies:
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.7"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.7"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.7":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.7":
   version "7.26.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.7.tgz#99a0a136f6a75e7fb8b0a1ace421e0b25994b8bb"
   integrity sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==
@@ -3513,16 +3500,7 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3547,14 +3525,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3847,16 +3818,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- Introduced salt parameter for more secure key hashing
- Updated sync method to reset stores before saving new gates
- Modified example app to demonstrate new feature flag usage
- Bumped package version to 1.0.0-alpha.8